### PR TITLE
Make recursiveDelete-function deleting symlinks

### DIFF
--- a/index.php
+++ b/index.php
@@ -837,7 +837,11 @@ EOF;
 			if ($fileInfo->isDir()) {
 				$directories[] = $fileInfo->getRealPath();
 			} else {
-				$files[] = $fileInfo->getRealPath();
+				if ($fileInfo->isLink()) {
+				    $files[] = $fileInfo->getPathName();
+				} else {
+				    $files[] = $fileInfo->getRealPath();
+				}
 			}
 		}
 		


### PR DESCRIPTION
Symlinks are not handled correct. $fileInfo->getRealPath() delivers an empty result for symlink files. Therefore I added another if to check if it is a link.
A part of issue #158 can be solved with this pull-request.
@MorrisJobke, what do you think of this?